### PR TITLE
fix: Fixed cancel warning dialog showing after download finish

### DIFF
--- a/src/ui/downloadwindow.cpp
+++ b/src/ui/downloadwindow.cpp
@@ -32,6 +32,7 @@ DownloadWindow::DownloadWindow(QWidget *parent)
     , ui(new Ui::DownloadWindow)
     , download(new Downloader(this))
 {
+    m_isWorking = true;
     ui->setupUi(this);
     AppGlobals::instance().setDownloadWindow(this);
     ui->adress->setReadOnly(true);
@@ -245,6 +246,7 @@ void DownloadWindow::onDownloadFinish(bool success, const QString &message)
     info.status = "Completed";
     emit DownloadInfo(info);
 
+    m_isWorking = false;
     FinishWindow finish(nullptr, info.url, info.savePath);
 
     QSystemTrayIcon tray;
@@ -313,9 +315,12 @@ void DownloadWindow::on_Pause_clicked()
 
 void DownloadWindow::closeEvent(QCloseEvent *event)
 {
-    downloadStop();
-    if (didStop)
-        event->accept();
-    else
-        event->ignore();
+    if(m_isWorking)
+    {
+        downloadStop();
+        if (didStop)
+            event->accept();
+        else
+            event->ignore();
+    }
 }

--- a/src/ui/downloadwindow.h
+++ b/src/ui/downloadwindow.h
@@ -68,6 +68,7 @@ private:
     bool didStop = false;
     qint64 lastProgress = 0;
     qint64 lastDownloaded = 0;
+    bool m_isWorking;
 };
 
 #endif // DOWNLOADWINDOW_H


### PR DESCRIPTION
## Description
Fixed cancel warning dialog showing after download is finished

Fixes #6 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [ ] Built successfully with Qt Creator / CMake
- [ ] Manual testing of the app

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have tested on a clean build and verified everything works
