### PR TITLE
Feat/add duplicate download option

### DIFF
--- a/src/ui/urldialog.cpp
+++ b/src/ui/urldialog.cpp
@@ -92,15 +92,29 @@ void urlDialog::on_buttonBox_accepted()
     {
         QMessageBox msg;
         msg.setWindowTitle("File Already Exists");
-        msg.setText("The target file already exists in the directory. \nDo you want to replace it?");
+        msg.setText("The target file already exists in the directory. \nDo you want to replace it, add a duplicate with a numbered file name or cancel?");
         msg.setIcon(QMessageBox::Warning);
-        QPushButton *No = msg.addButton("No", QMessageBox::DestructiveRole);
-        QPushButton *Yes = msg.addButton("Yes", QMessageBox::AcceptRole);
-        msg.setDefaultButton(Yes);
+        QPushButton *Cancel = msg.addButton("Cancel", QMessageBox::DestructiveRole);
+        QPushButton *Duplicate = msg.addButton("Duplicate", QMessageBox::ActionRole);
+        QPushButton *Replace = msg.addButton("Replace", QMessageBox::ActionRole);
+        msg.setDefaultButton(Replace);
         msg.exec();
-        if (msg.clickedButton() == Yes)
+        if (msg.clickedButton() == Replace)
         {
             QFile::remove(savePath);
+            DownloadWindow *window = new DownloadWindow(nullptr);
+            window->startDownload(info);
+            window->setAttribute(Qt::WA_DeleteOnClose);
+            window->show();
+        }
+        else if (msg.clickedButton() == Duplicate)
+        {
+            QFileInfo fileInfo(info.fileName);
+            QString newName = fileInfo.baseName() + "_1." + fileInfo.completeSuffix();
+            QUrl savePath(info.savePath);
+            QString newPath = savePath.adjusted(QUrl::RemoveFilename).toString() + newName;
+            info.fileName = newName;
+            info.savePath = newPath;
             DownloadWindow *window = new DownloadWindow(nullptr);
             window->startDownload(info);
             window->setAttribute(Qt::WA_DeleteOnClose);

--- a/src/ui/urldialog.cpp
+++ b/src/ui/urldialog.cpp
@@ -109,12 +109,28 @@ void urlDialog::on_buttonBox_accepted()
         }
         else if (msg.clickedButton() == Duplicate)
         {
-            QFileInfo fileInfo(info.fileName);
-            QString newName = fileInfo.baseName() + "_1." + fileInfo.completeSuffix();
-            QUrl savePath(info.savePath);
-            QString newPath = savePath.adjusted(QUrl::RemoveFilename).toString() + newName;
+            QFileInfo fileInfo(info.savePath);
+
+            QString baseName = fileInfo.completeBaseName();
+            QString suffix = fileInfo.completeSuffix();
+            QString dir = fileInfo.absolutePath();
+
+            QString newName, newPath;
+
+            int i = 0;
+
+            while (fileInfo.exists())
+            {
+                newName = QString("%1_%2.%3").arg(baseName).arg(i).arg(suffix);
+                newPath = QDir(dir).filePath(newName);
+
+                fileInfo.setFile(newPath);
+                ++i;
+            }
+
             info.fileName = newName;
             info.savePath = newPath;
+
             DownloadWindow *window = new DownloadWindow(nullptr);
             window->startDownload(info);
             window->setAttribute(Qt::WA_DeleteOnClose);


### PR DESCRIPTION
## Description
Added the duplicate download option when starting a download.

Fixes #4

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [ ] Built successfully with Qt Creator / CMake
- [ ] Manual testing of the app

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have tested on a clean build and verified everything works
